### PR TITLE
Hide and show traces

### DIFF
--- a/src/components/Legend.tsx
+++ b/src/components/Legend.tsx
@@ -28,7 +28,7 @@ export function Legend() {
     <div className="pointer-events-auto bg-white/80 dark:bg-neutral-900/80 backdrop-blur rounded-md border border-gray-300 dark:border-neutral-700 p-2 max-w-xs">
       <div className="text-xs font-semibold mb-1">Legend</div>
       <div className="flex flex-col gap-1">
-        {series.map((s) => (
+        {series.filter(s => s.visible).map((s) => (
           <button key={s.id} className="flex items-center gap-2 text-left text-xs hover:opacity-90 cursor-pointer" onClick={() => setEditingId(s.id)}>
             <span className="inline-block w-3 h-3 rounded-sm" style={{ background: s.color }} />
             <span className="truncate">{s.name}</span>

--- a/src/components/__tests__/Legend.test.tsx
+++ b/src/components/__tests__/Legend.test.tsx
@@ -6,8 +6,8 @@ import Legend from '../Legend'
 const renameSeries = vi.fn()
 const setSeriesColor = vi.fn()
 const mockSeries = [
-  { id: 0, name: 'Channel A', color: '#ff0000' },
-  { id: 1, name: 'Channel B', color: '#00ff00' },
+  { id: 0, name: 'Channel A', color: '#ff0000', visible: true },
+  { id: 1, name: 'Channel B', color: '#00ff00', visible: true },
 ]
 
 vi.mock('../../store/dataStore', () => ({

--- a/src/components/__tests__/PlotCanvas.test.tsx
+++ b/src/components/__tests__/PlotCanvas.test.tsx
@@ -3,7 +3,7 @@ import { render } from '@testing-library/react'
 import { PlotCanvas } from '../PlotCanvas'
 
 function makeSnapshot(values: number[]) {
-  const series = [{ id: 0, name: 'S1', color: '#fff' }]
+  const series = [{ id: 0, name: 'S1', color: '#fff', visible: true }]
   const data = new Float32Array(values)
   return {
     series,

--- a/src/components/__tests__/SeriesPanel.test.tsx
+++ b/src/components/__tests__/SeriesPanel.test.tsx
@@ -5,8 +5,8 @@ import SeriesPanel from '../SeriesPanel'
 const renameSeries = vi.fn()
 const setSeriesColor = vi.fn()
 const mockSeries = [
-  { id: 0, name: 'S1', color: '#111111' },
-  { id: 1, name: 'S2', color: '#222222' },
+  { id: 0, name: 'S1', color: '#111111', visible: true },
+  { id: 1, name: 'S2', color: '#222222', visible: true },
 ]
 
 vi.mock('../../store/dataStore', () => ({

--- a/src/components/__tests__/StatsPanel.test.tsx
+++ b/src/components/__tests__/StatsPanel.test.tsx
@@ -2,9 +2,10 @@ import type { PlotSnapshot } from '../../types/plot'
 import { describe, it, expect } from 'vitest'
 import { render, screen } from '@testing-library/react'
 import { StatsPanel } from '../StatsPanel'
+import { DataStoreProvider } from '../../store/dataStore'
 
 function makeSnapshot(values: number[]) {
-  const series = [{ id: 0, name: 'S1', color: '#fff' }]
+  const series = [{ id: 0, name: 'S1', color: '#fff', visible: true }]
   const data = new Float32Array(values)
   return {
     series,
@@ -20,7 +21,11 @@ function makeSnapshot(values: number[]) {
 describe('StatsPanel', () => {
   it('renders stats values for a single series', () => {
     const snap = makeSnapshot([1, 2, 3, 4]) as unknown as PlotSnapshot
-    render(<StatsPanel snapshot={snap} />)
+    render(
+      <DataStoreProvider>
+        <StatsPanel snapshot={snap} />
+      </DataStoreProvider>
+    )
     expect(screen.getByText('S1')).toBeInTheDocument()
     expect(screen.getByText(/min:/i)).toBeInTheDocument()
     expect(screen.getByText(/max:/i)).toBeInTheDocument()

--- a/src/store/__tests__/RingStore.test.ts
+++ b/src/store/__tests__/RingStore.test.ts
@@ -37,9 +37,9 @@ describe('RingStore', () => {
       // Create 3 series by appending data
       store.append([1, 2, 3])
       const series = store.getSeries()
-      expect(series[0]).toEqual({ id: 0, name: 'S1', color: '#60a5fa' })
-      expect(series[1]).toEqual({ id: 1, name: 'S2', color: '#f472b6' })
-      expect(series[2]).toEqual({ id: 2, name: 'S3', color: '#34d399' })
+      expect(series[0]).toEqual({ id: 0, name: 'S1', color: '#60a5fa', visible: true })
+      expect(series[1]).toEqual({ id: 1, name: 'S2', color: '#f472b6', visible: true })
+      expect(series[2]).toEqual({ id: 2, name: 'S3', color: '#34d399', visible: true })
     })
 
     it('should set new series', () => {
@@ -67,6 +67,22 @@ describe('RingStore', () => {
       const originalName = store.getSeries()[0].name
       store.renameSeries(999, 'InvalidID')
       expect(store.getSeries()[0].name).toBe(originalName)
+    })
+
+    it('should toggle series visibility', () => {
+      store.append([1, 2, 3]) // Create series first
+      expect(store.getSeries()[0].visible).toBe(true)
+      store.toggleSeriesVisibility(0)
+      expect(store.getSeries()[0].visible).toBe(false)
+      store.toggleSeriesVisibility(0)
+      expect(store.getSeries()[0].visible).toBe(true)
+    })
+
+    it('should handle invalid series ID for toggle visibility', () => {
+      store.append([1, 2, 3]) // Create series first
+      const originalVisibility = store.getSeries()[0].visible
+      store.toggleSeriesVisibility(999)
+      expect(store.getSeries()[0].visible).toBe(originalVisibility)
     })
   })
 

--- a/src/types/plot.ts
+++ b/src/types/plot.ts
@@ -3,6 +3,7 @@ export interface PlotSeries {
   id: number
   name: string
   color: string
+  visible: boolean
 }
 
 /**

--- a/src/utils/__tests__/chartExport.test.ts
+++ b/src/utils/__tests__/chartExport.test.ts
@@ -4,8 +4,8 @@ import type { ViewPortData } from '../../store/RingStore'
 
 const mockViewPortData: ViewPortData = {
   series: [
-    { id: 0, name: 'Temperature', color: '#ff0000' },
-    { id: 1, name: 'Humidity', color: '#00ff00' }
+    { id: 0, name: 'Temperature', color: '#ff0000', visible: true },
+    { id: 1, name: 'Humidity', color: '#00ff00', visible: true }
   ],
   getSeriesData: (id: number) => {
     if (id === 0) return new Float32Array([23.5, 24.0, 24.5, NaN])
@@ -22,8 +22,8 @@ const mockViewPortData: ViewPortData = {
 
 const mockStore = {
   getSeries: () => [
-    { id: 0, name: 'Temperature', color: '#ff0000' },
-    { id: 1, name: 'Humidity', color: '#00ff00' }
+    { id: 0, name: 'Temperature', color: '#ff0000', visible: true },
+    { id: 1, name: 'Humidity', color: '#00ff00', visible: true }
   ],
   getCapacity: () => 5,
   writeIndex: 4,

--- a/src/utils/__tests__/plotRendering.drawSeries.test.ts
+++ b/src/utils/__tests__/plotRendering.drawSeries.test.ts
@@ -14,7 +14,7 @@ describe('drawSeries', () => {
     const ctx = makeCtx()
     const chart = { x: 0, y: 0, width: 100, height: 50 }
     const snapshot = {
-      series: [{ id: 0, name: 'S1', color: '#fff' }],
+      series: [{ id: 0, name: 'S1', color: '#fff', visible: true }],
       getSeriesData: () => new Float32Array([0, NaN, 1, 2]),
       viewPortSize: 4,
     } as unknown as import('../../store/RingStore').ViewPortData
@@ -23,6 +23,24 @@ describe('drawSeries', () => {
     expect(ctx.clip).toHaveBeenCalled()
     expect(ctx.beginPath).toHaveBeenCalled()
     expect(ctx.stroke).toHaveBeenCalled()
+  })
+
+  it('skips hidden series', () => {
+    const ctx = makeCtx()
+    const chart = { x: 0, y: 0, width: 100, height: 50 }
+    const snapshot = {
+      series: [
+        { id: 0, name: 'S1', color: '#fff', visible: false },
+        { id: 1, name: 'S2', color: '#aaa', visible: true }
+      ],
+      getSeriesData: (id: number) => id === 0 ? new Float32Array([1, 2, 3]) : new Float32Array([4, 5, 6]),
+      viewPortSize: 3,
+    } as unknown as import('../../store/RingStore').ViewPortData
+    
+    drawSeries(ctx, chart, snapshot, -1, 10)
+    
+    // Should only draw once (for visible series S2), not twice
+    expect(ctx.stroke).toHaveBeenCalledTimes(1)
   })
 })
 

--- a/src/utils/plotRendering.ts
+++ b/src/utils/plotRendering.ts
@@ -291,6 +291,9 @@ export function drawSeries(
   
   // Draw each series
   for (const series of snapshot.series) {
+    // Skip hidden series
+    if (!series.visible) continue
+    
     const data = snapshot.getSeriesData(series.id)
     if (!data || data.length === 0) continue
     
@@ -384,9 +387,12 @@ export function drawHoverTooltip(
   const timestamp = times[sampleIndex]
   if (!Number.isFinite(timestamp)) return // Skip NaN timestamps
   
-  // Collect all series values at this index
+  // Collect all series values at this index (only for visible series)
   const values: Array<{ name: string; value: number; color: string }> = []
   for (const series of snapshot.series) {
+    // Skip hidden series
+    if (!series.visible) continue
+    
     const data = snapshot.getSeriesData(series.id)
     if (sampleIndex < data.length) {
       const value = data[sampleIndex]


### PR DESCRIPTION
## Summary

Adds the ability to hide and show traxces.

## Motivation & Context

Closes #14

## Changes

Adds a checkbox to the stats panels that lets you turn traces off and on.

## Screenshots / Demos (if UI)

<img width="1479" height="731" alt="Screenshot 2025-10-01 at 22 29 34" src="https://github.com/user-attachments/assets/577b742a-92b6-421e-bc33-f89c68996b9b" />

## How to Test

1. Start plotting
2. Click the checkbox on the stats panel on and off


## Checklist

- [x] I ran `npm run lint` and fixed any issues
- [x] I ran `npm run typecheck` (TypeScript) with no errors
- [x] I ran `npm test` and tests pass
- [x] I ran `npm run test:coverage` if code paths changed significantly
- [x] I added/updated tests where appropriate
- [x] I updated docs/README if needed
- [x] No breaking changes without clear migration notes


## Additional Notes

I thought about doing this in the legend, but felt that might get a bit busy.

