### PR TITLE
Allow sending of CTRL-C and CTRL-D

### DIFF
--- a/src/components/ConsoleInput.tsx
+++ b/src/components/ConsoleInput.tsx
@@ -25,7 +25,29 @@ export default function ConsoleInput({ onSend, disabled = false }: ConsoleInputP
     setHistoryIndex(-1)
   }, [input, disabled, onSend, history])
 
+  const sendControlChar = useCallback((char: 'C' | 'D') => {
+    if (disabled) return
+    
+    // Send control character (Ctrl-C = 0x03, Ctrl-D = 0x04)
+    const code = char === 'C' ? 3 : 4
+    const controlChar = String.fromCharCode(code)
+    onSend(controlChar)
+  }, [disabled, onSend])
+
   const handleKeyDown = useCallback((e: KeyboardEvent<HTMLInputElement>) => {
+    // Handle Ctrl-C and Ctrl-D
+    if (e.ctrlKey || e.metaKey) {
+      if (e.key === 'c' || e.key === 'C') {
+        e.preventDefault()
+        sendControlChar('C')
+        return
+      } else if (e.key === 'd' || e.key === 'D') {
+        e.preventDefault()
+        sendControlChar('D')
+        return
+      }
+    }
+    
     if (e.key === 'Enter') {
       e.preventDefault()
       handleSend()
@@ -51,7 +73,7 @@ export default function ConsoleInput({ onSend, disabled = false }: ConsoleInputP
         }
       }
     }
-  }, [handleSend, history, historyIndex])
+  }, [handleSend, history, historyIndex, sendControlChar])
 
   return (
     <div className="flex gap-2 p-3 border-t border-gray-200 dark:border-neutral-800 bg-white dark:bg-neutral-950">
@@ -61,10 +83,26 @@ export default function ConsoleInput({ onSend, disabled = false }: ConsoleInputP
         value={input}
         onChange={(e) => setInput(e.target.value)}
         onKeyDown={handleKeyDown}
-        placeholder={disabled ? "Not connected" : "Type command and press Enter..."}
+        placeholder={disabled ? "Not connected" : "Type command and press Enter (Ctrl-C, Ctrl-D supported)..."}
         disabled={disabled}
         className="flex-1 px-3 py-2 text-sm border border-gray-300 dark:border-neutral-700 rounded-md bg-white dark:bg-neutral-900 text-gray-900 dark:text-neutral-100 placeholder-gray-400 dark:placeholder-neutral-500 focus:outline-none focus:ring-2 focus:ring-blue-500 dark:focus:ring-blue-400 disabled:opacity-50 disabled:cursor-not-allowed"
       />
+      <button
+        onClick={() => sendControlChar('C')}
+        disabled={disabled}
+        title="Send Ctrl-C (interrupt)"
+        className="px-3 py-2 text-sm font-medium text-white bg-orange-600 hover:bg-orange-700 dark:bg-orange-500 dark:hover:bg-orange-600 rounded-md transition-colors disabled:opacity-50 disabled:cursor-not-allowed disabled:hover:bg-orange-600 dark:disabled:hover:bg-orange-500"
+      >
+        ^C
+      </button>
+      <button
+        onClick={() => sendControlChar('D')}
+        disabled={disabled}
+        title="Send Ctrl-D (EOF)"
+        className="px-3 py-2 text-sm font-medium text-white bg-purple-600 hover:bg-purple-700 dark:bg-purple-500 dark:hover:bg-purple-600 rounded-md transition-colors disabled:opacity-50 disabled:cursor-not-allowed disabled:hover:bg-purple-600 dark:disabled:hover:bg-purple-500"
+      >
+        ^D
+      </button>
       <button
         onClick={handleSend}
         disabled={!input.trim() || disabled}

--- a/src/components/SerialConsole.tsx
+++ b/src/components/SerialConsole.tsx
@@ -17,11 +17,20 @@ export default function SerialConsole({ isConnected, onSendMessage }: SerialCons
 
   const handleSendMessage = useCallback(async (message: string) => {
     try {
-      // Add newline to message if not present
-      const messageToSend = message.endsWith('\n') ? message : message + '\n'
+      // Check if message is a control character (ASCII 0-31)
+      const isControlChar = message.length === 1 && message.charCodeAt(0) < 32
       
-      // Log outgoing message
-      addOutgoing(message)
+      // Add newline to message if not present (unless it's a control character)
+      const messageToSend = isControlChar ? message : (message.endsWith('\n') ? message : message + '\n')
+      
+      // Log outgoing message with readable name for control chars
+      if (isControlChar) {
+        const code = message.charCodeAt(0)
+        const ctrlName = code === 3 ? '^C (ETX)' : code === 4 ? '^D (EOT)' : `^${String.fromCharCode(64 + code)}`
+        addOutgoing(ctrlName)
+      } else {
+        addOutgoing(message)
+      }
       
       // Send via serial
       await onSendMessage(messageToSend)


### PR DESCRIPTION
<!--
Thank you for your contribution! Please fill out the sections below to help us review.
Keep it concise and high-signal. Remove sections that don't apply.
-->

## Summary

Adds buttons for sending CTRL-C and CTRL-D

## Motivation & Context

Closes #13


## Changes

Adds buttons for sending these codes

## Screenshots / Demos (if UI)

<img width="385" height="148" alt="Screenshot 2025-10-01 at 22 40 12" src="https://github.com/user-attachments/assets/6df07e63-eccb-48b6-b074-29fb18ef1d4e" />

## How to Test

1. Connect to serial 
2. Try the new buttons


## Checklist

- [x] I ran `npm run lint` and fixed any issues
- [x] I ran `npm run typecheck` (TypeScript) with no errors
- [x] I ran `npm test` and tests pass
- [x] I ran `npm run test:coverage` if code paths changed significantly
- [x] I added/updated tests where appropriate
- [x] I updated docs/README if needed
- [x] No breaking changes without clear migration notes


## Additional Notes

<!-- Anything else reviewers should know? Trade-offs, follow-ups, or risks. -->


