### PR TITLE
Increase timestamp precision to milliseconds in serial console log

### DIFF
--- a/src/components/ConsoleLog.tsx
+++ b/src/components/ConsoleLog.tsx
@@ -26,7 +26,15 @@ export default function ConsoleLog({ messages }: ConsoleLogProps) {
   }
 
   const formatTimestamp = (timestamp: number) => {
-    return new Date(timestamp).toLocaleTimeString()
+    return new Date(timestamp).toLocaleTimeString(
+      undefined, // use default locale
+      {
+        hour: "2-digit",
+        minute: "2-digit",
+        second: "2-digit",
+        fractionalSecondDigits: 3
+      }
+    )
   }
 
   const getMessageClasses = (message: ConsoleMessage) => {


### PR DESCRIPTION
<!--
Thank you for your contribution! Please fill out the sections below to help us review.
Keep it concise and high-signal. Remove sections that don't apply.
-->

## Summary

<!-- What does this PR do? A brief, human-friendly description. -->


## Motivation & Context

<!-- Why is this change needed? Link to issues, context, or user stories. -->
Closes #30


## Changes

<!-- High-level list of notable changes. -->
- Changes timestamp format in serial console logs from HH:MM:SS to HH:MM:SS.SSS


## Screenshots / Demos (if UI)

<!-- Add before/after screenshots or GIFs as appropriate. -->


## How to Test

<!-- Steps for a reviewer to verify locally. Include data/flags if relevant. -->
1. Connect a data source
2. Switch to the Console tab and verify that timestamps have millisecond precision
3. Check that timestamps are still localized properly


## Checklist

- [x] I ran `npm run lint` and fixed any issues
- [x] I ran `npm run typecheck` (TypeScript) with no errors
- [x] I ran `npm test` and tests pass
- [ ] I ran `npm run test:coverage` if code paths changed significantly
- [ ] I added/updated tests where appropriate
- [ ] I updated docs/README if needed
- [x] No breaking changes without clear migration notes


## Additional Notes

<!-- Anything else reviewers should know? Trade-offs, follow-ups, or risks. -->

This uses HH:MM:SS.SSS instead of HH:MM:SS:XXX which was suggested in #30